### PR TITLE
Sync video with system time feature

### DIFF
--- a/Assets/AttractionScreen/AttractionScreen.cs
+++ b/Assets/AttractionScreen/AttractionScreen.cs
@@ -21,6 +21,8 @@ namespace Zhdk.Gamelab
         [SerializeField] private bool freezeTimeDuringScreen = false;
         [Tooltip("Start the video once the scenes got loaded")]
         [SerializeField] private bool startVideoAfterSceneLoad;
+        [Tooltip("Set the video's time to be in sync with the system time. Useful for having multiple devices running the attraction screen in sync.\nNote: Only works if every device's video has the same length")]
+        [SerializeField] private bool syncVideoToSystemTime = true;
         [Tooltip("The scene / scenes you want to load once we start the attraction screen")]
         [SerializeField] private List<string> restartScenes = new List<string>();
 
@@ -105,6 +107,13 @@ namespace Zhdk.Gamelab
 
             if(startVideoAfterSceneLoad == false)
             {
+                if (syncVideoToSystemTime)
+                {
+                    double systemTime = System.DateTime.Now.TimeOfDay.TotalSeconds;
+                    float videoLength = videoPlayer.frameCount / videoPlayer.frameRate;
+                    videoPlayer.time = systemTime % videoLength;
+                }
+
                 videoPlayer.Play();
                 canvas.enabled = true;
             }
@@ -118,6 +127,13 @@ namespace Zhdk.Gamelab
 
             if (startVideoAfterSceneLoad)
             {
+                if (syncVideoToSystemTime)
+                {
+                    double systemTime = System.DateTime.Now.TimeOfDay.TotalSeconds;
+                    float videoLength = videoPlayer.frameCount / videoPlayer.frameRate;
+                    videoPlayer.time = systemTime % videoLength;
+                }
+
                 videoPlayer.Play();
                 canvas.enabled = true;
             }

--- a/Assets/AttractionScreen/AttractionScreen.cs
+++ b/Assets/AttractionScreen/AttractionScreen.cs
@@ -105,37 +105,49 @@ namespace Zhdk.Gamelab
                 Time.timeScale = 0;
             }
 
-            if(startVideoAfterSceneLoad == false)
-            {
-                if (syncVideoToSystemTime)
+            if (startVideoAfterSceneLoad) {
+                // load scenes
+                for(int i = 0; i < restartScenes.Count; i++)
                 {
-                    double systemTime = System.DateTime.Now.TimeOfDay.TotalSeconds;
-                    float videoLength = videoPlayer.frameCount / videoPlayer.frameRate;
-                    videoPlayer.time = systemTime % videoLength;
+                    // load first scene and make it the active one
+                    SceneManager.LoadScene(restartScenes[i], i == 0 ? LoadSceneMode.Single: LoadSceneMode.Additive);
                 }
-
-                videoPlayer.Play();
-                canvas.enabled = true;
             }
 
-            // load scenes
-            for(int i = 0; i < restartScenes.Count; i++)
+            if (syncVideoToSystemTime)
             {
-                // load first scene and make it the active one
-                SceneManager.LoadScene(restartScenes[i], i == 0 ? LoadSceneMode.Single: LoadSceneMode.Additive);
+                double systemTime = System.DateTime.Now.TimeOfDay.TotalSeconds;
+                float videoLength = videoPlayer.frameCount / videoPlayer.frameRate;
+                videoPlayer.time = systemTime % videoLength;
             }
 
-            if (startVideoAfterSceneLoad)
-            {
-                if (syncVideoToSystemTime)
-                {
-                    double systemTime = System.DateTime.Now.TimeOfDay.TotalSeconds;
-                    float videoLength = videoPlayer.frameCount / videoPlayer.frameRate;
-                    videoPlayer.time = systemTime % videoLength;
-                }
+            // To prevent incorrect frames when starting video
+            videoPlayer.Prepare();
 
-                videoPlayer.Play();
-                canvas.enabled = true;
+            // Wait for video to be ready to play
+            while (videoPlayer.isPrepared == false) {
+                yield return null;
+            }
+
+            videoPlayer.Play();
+
+            // Wait some more...
+            for(int i = 0; i < 10; i ++)
+            {
+                yield return null;
+            }
+
+            // Finally show the video
+            canvas.enabled = true;
+
+            if (startVideoAfterSceneLoad == false)
+            {
+                // load scenes
+                for(int i = 0; i < restartScenes.Count; i++)
+                {
+                    // load first scene and make it the active one
+                    SceneManager.LoadScene(restartScenes[i], i == 0 ? LoadSceneMode.Single: LoadSceneMode.Additive);
+                }
             }
 
             while (GetAnyInput() == false)


### PR DESCRIPTION
Adds the option (default on) to sync the video playback to the system time.
This is useful to be able to have attraction screen videos across multiple devices play in sync (as long as they are the same length).