### PR TITLE
Reduce default idleTimeLimit to 60s

### DIFF
--- a/Assets/AttractionScreen/AttractionScreen.cs
+++ b/Assets/AttractionScreen/AttractionScreen.cs
@@ -14,7 +14,7 @@ namespace Zhdk.Gamelab
         public float IdleTimeLimit => idleTimeLimit;
 
         [Tooltip("The time the game can idle before starting the attraction screen")]
-        [SerializeField] private float idleTimeLimit = 180;
+        [SerializeField] private float idleTimeLimit = 60;
         [Tooltip("If this option is enabled the idle time goes up even if Time.timeScale is on 0")]
         [SerializeField] private bool useUnscaledTime = true;
         [Tooltip("Game-play time will be frozen during the attraction screen")]


### PR DESCRIPTION
180s of idle time before the attraction screen starts is too long for most projects. Every year many students don't think of changing the value, so a change to the default is in order. 60s is a more sensible but still generous default.